### PR TITLE
fix: return http status 500 when we have internal server error

### DIFF
--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/config/openapi/GlobalExceptionHandler.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/config/openapi/GlobalExceptionHandler.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
 
-	//ExceptionHandler(Exception.class)
+	@ExceptionHandler(Exception.class)
 	ProblemDetail handleException(Exception e) {
 		log.error("Error ", e);
 		String errorMsg = ExceptionUtils.getMessage(e);

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/config/openapi/GlobalExceptionHandler.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/config/openapi/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.config.openapi;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+
+	//ExceptionHandler(Exception.class)
+	ProblemDetail handleException(Exception e) {
+		log.error("Error ", e);
+		String errorMsg = ExceptionUtils.getMessage(e);
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, errorMsg);
+		problemDetail.setTitle(errorMsg);
+		problemDetail.setProperty(System.currentTimeMillis()+"", System.currentTimeMillis());
+		return problemDetail;
+	}
+
+}


### PR DESCRIPTION
Error:

in the current code, if we get any internal server error API returns 200  with the below response: without printing stack trace of the exception. 

```
{
  "code": "0",
  "lastDigits": "00"
}
```


Fix: 

Exception handler added to which print stack trace and give HTTP status 500